### PR TITLE
Fix list-response validation and align models with live API responses

### DIFF
--- a/eero/client/models/account.py
+++ b/eero/client/models/account.py
@@ -21,7 +21,7 @@ class NetworkInfo(BaseModel):
     created: str
     nickname_label: str | None = None
     access_expires_on: datetime | None = None
-    amazon_directed_id: str
+    amazon_directed_id: str | None = None
 
     @property
     def id(self):
@@ -45,7 +45,7 @@ class PremiumDetails(BaseModel):
     tier: str
     is_iap_customer: bool
     payment_method: str | None = None
-    interval: str
+    interval: str | None = None
     next_billing_event_date: datetime | None = None
 
 

--- a/eero/client/models/device.py
+++ b/eero/client/models/device.py
@@ -77,6 +77,17 @@ class RoutingDeviceData(BaseModel):
     nickname: str | None = None
 
 
+class DeviceUsage(BaseModel):
+    down_mbps: float
+    up_mbps: float
+
+
+class DeviceIPv6Address(BaseModel):
+    address: str
+    scope: str
+    interface: str | None = None
+
+
 class ProfileDevice(RoutingDeviceData):
     model_config = ConfigDict(protected_namespaces=())
     manufacturer: str | None = None
@@ -92,7 +103,7 @@ class ProfileDevice(RoutingDeviceData):
     first_active: datetime | None = None
     connectivity: DeviceConnectivity
     interface: Interface
-    usage: str | None = None
+    usage: DeviceUsage | str | None = None
     homekit: HomeKit | None = None
     device_type: str
     auth: str | None = None
@@ -104,7 +115,7 @@ class ProfileDevice(RoutingDeviceData):
 
 class Device(ProfileDevice):
     eui64: str
-    ipv6_addresses: list[str]
+    ipv6_addresses: list[DeviceIPv6Address | str]
     profile: Profile | None = None
     blacklisted: bool | None = None
     is_guest: bool

--- a/eero/client/models/networks.py
+++ b/eero/client/models/networks.py
@@ -431,7 +431,7 @@ class Networks(BaseModel):
     amazon_device_nickname: bool
     vlan: str | None = None
     ddns: DDNS
-    ring_lte: RingLTE
+    ring_lte: RingLTE | None = None
     pppoe_username: str | None = None
     pppoe_enabled: str | None = None
     proxied_nodes: str | None = None

--- a/eero/client/models/networks.py
+++ b/eero/client/models/networks.py
@@ -366,6 +366,12 @@ class IPV6Settings(BaseModel):
     name_servers: NameServers
 
 
+class IPv6Lease(BaseModel):
+    prefix: str | None = None
+    subnets: list[str] | None = None
+    name_servers: list[str] | None = None
+
+
 class GuestNetwork(BaseModel):
     url: str
     resources: dict[str, str]
@@ -432,9 +438,9 @@ class Networks(BaseModel):
     owner: str
     premium_status: str
     rebooting: str | None = None
-    last_reboot: datetime
+    last_reboot: datetime | None = None
     homekit: str | None = None
-    ipv6_lease: str | None = None
+    ipv6_lease: IPv6Lease | str | None = None
     ipv6: IPV6Settings
     organization: str | None = None
     image_assets: str | None = None

--- a/eero/client/models/networks.py
+++ b/eero/client/models/networks.py
@@ -391,6 +391,12 @@ class RingLTE(BaseModel):
     apn: str | None = None
 
 
+class NetworkHomeKit(BaseModel):
+    enabled: bool
+    enabledLastChanged: datetime | None = None
+    managedNetworkEnabled: bool
+
+
 class PremiumDetails(BaseModel):
     trial_ends: datetime | None = None
     has_payment_info: bool
@@ -439,7 +445,7 @@ class Networks(BaseModel):
     premium_status: str
     rebooting: str | None = None
     last_reboot: datetime | None = None
-    homekit: str | None = None
+    homekit: NetworkHomeKit | str | None = None
     ipv6_lease: IPv6Lease | str | None = None
     ipv6: IPV6Settings
     organization: str | None = None

--- a/eero/client/models/networks.py
+++ b/eero/client/models/networks.py
@@ -122,9 +122,16 @@ class DHCPIP(BaseModel):
     router: str
 
 
+class DHCPCustomRange(BaseModel):
+    subnet_ip: str
+    subnet_mask: str | None = None
+    start_ip: str | None = None
+    end_ip: str | None = None
+
+
 class DHCP(BaseModel):
     mode: str
-    custom: str | None = None
+    custom: DHCPCustomRange | str | None = None
 
 
 class Lease(BaseModel):
@@ -198,6 +205,17 @@ class EeroDeviceBandDetails(BaseModel):
     ethernet_address: str
 
 
+class NightlightSchedule(BaseModel):
+    on: str | None = None
+    off: str | None = None
+
+
+class Nightlight(BaseModel):
+    enabled: bool
+    brightness: int | None = None
+    schedule: NightlightSchedule | None = None
+
+
 class Message(BaseModel):
     value: str
 
@@ -217,7 +235,7 @@ class EeroDevice(BaseModel):
     messages: list[Message]
     model: str
     model_number: str
-    ethernet_addresses: list[str]
+    ethernet_addresses: list[str] | None = None
     ethernet_status: EeroDeviceEthernetStatus | None = None
     wifi_bssids: list[str]
     update_available: bool
@@ -230,7 +248,7 @@ class EeroDevice(BaseModel):
     led_brightness: int
     using_wan: bool
     is_primary_node: bool
-    nightlight: str | None = None
+    nightlight: Nightlight | str | None = None
     last_reboot: datetime | None = None
     mac_address: str
     ipv6_addresses: list[IP6Address]

--- a/eero/client/models/networks.py
+++ b/eero/client/models/networks.py
@@ -157,11 +157,11 @@ class EeroDeviceEthernetStatusItem(BaseModel):
     isWanPort: bool
     isLte: bool
     isLeafWiredToUpstream: bool
-    neighbor: str | None = None
+    neighbor: str | dict[str, Any] | None = None
     power_saving: bool
     original_speed: str | None = None
     derated_reason: str | None = None
-    lldpInfo: list[dict[str, str]]
+    lldpInfo: list[dict[str, str | None]]
 
 
 class EeroDeviceEthernetStatus(BaseModel):
@@ -231,7 +231,7 @@ class EeroDevice(BaseModel):
     using_wan: bool
     is_primary_node: bool
     nightlight: str | None = None
-    last_reboot: datetime
+    last_reboot: datetime | None = None
     mac_address: str
     ipv6_addresses: list[IP6Address]
     organization: str | None = None

--- a/eero/client/models/networks.py
+++ b/eero/client/models/networks.py
@@ -373,7 +373,7 @@ class PremiumDetails(BaseModel):
     tier: str
     is_iap_customer: bool | None = None
     payment_method: str | None = None
-    interval: str
+    interval: str | None = None
     next_billing_event_date: datetime | None = None
     is_my_subscription: bool
 
@@ -423,8 +423,8 @@ class Networks(BaseModel):
     access_expires_on: datetime | None = None
     guest_network: GuestNetwork
     amazon_account_linked: bool
-    amazon_directed_id: str
-    amazon_full_name: str
+    amazon_directed_id: str | None = None
+    amazon_full_name: str | None = None
     ffs: bool
     temporary_flags: dict[str, Any]
     alexa_skill: bool

--- a/eero/client/models/thread.py
+++ b/eero/client/models/thread.py
@@ -16,5 +16,5 @@ class Thread(BaseModel):
     channel: int
     master_key: str
     commissioning_credential: str
-    border_agent: ThreadBorderAgent
+    border_agent: ThreadBorderAgent | None = None
     active_operational_dataset: str

--- a/eero/client/routes/method_factory.py
+++ b/eero/client/routes/method_factory.py
@@ -55,7 +55,7 @@ def make_method(method: str, action: str, resource: Resource, **kwargs: Any):
                 try:
                     if isinstance(result, list):
                         return TypeAdapter(
-                            list[type(model)]  # type: ignore
+                            list[model]  # type: ignore
                         ).validate_python(result)
                     return model.model_validate(result)  # type: ignore
                 except Exception as e:
@@ -70,7 +70,7 @@ def make_method(method: str, action: str, resource: Resource, **kwargs: Any):
 
             except ValidationError as e:
                 if model == ErrorMeta:
-                    logger.warn(f"Not Implemented: {action} (expected error)")
+                    logger.warning(f"Not Implemented: {action} (expected error)")
                     return result
                 logger.error("Failed to validate %s: %s", action, e)
         return result

--- a/tests/test_network_models.py
+++ b/tests/test_network_models.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+
+from pydantic import TypeAdapter
+
+from eero.client.models.networks import NetworkHomeKit
+
+
+def test_network_homekit_accepts_structured_api_response() -> None:
+    adapter: TypeAdapter[NetworkHomeKit | str | None] = TypeAdapter(
+        NetworkHomeKit | str | None
+    )
+
+    result = adapter.validate_python(
+        {
+            "enabled": True,
+            "enabledLastChanged": "2026-07-30T23:47:00Z",
+            "managedNetworkEnabled": False,
+        }
+    )
+
+    assert isinstance(result, NetworkHomeKit)
+    assert result.enabled is True
+    assert isinstance(result.enabledLastChanged, datetime)
+    assert result.managedNetworkEnabled is False
+
+
+def test_network_homekit_accepts_legacy_forms() -> None:
+    adapter: TypeAdapter[NetworkHomeKit | str | None] = TypeAdapter(
+        NetworkHomeKit | str | None
+    )
+
+    assert adapter.validate_python(None) is None
+    assert adapter.validate_python("enabled") == "enabled"


### PR DESCRIPTION
## Summary

Two classes of fixes, all verified against live API responses from 4 real networks (17 eero nodes across Pro 6E, PoE 6, and Beacon hardware):

1. **List-response validation is broken for every endpoint** (`method_factory.py`)
2. **Several models reject responses that real accounts/networks return** (nullable fields, object-vs-string shapes)

## 1. The list bug

```python
TypeAdapter(list[type(model)])  # type(model) is ModelMetaclass
```

`type(model)` on a model *class* yields pydantic's `ModelMetaclass`, so `TypeAdapter` raises `PydanticSchemaGenerationError` at construction time — for every list-shaped response (`devices`, `eeros`, `forwards`, `reservations`, `speedtest`, …), even an empty list. Because `PydanticSchemaGenerationError` is not a `ValidationError` subclass, it also escapes the `except ValidationError` fallback and propagates to the caller, and it made the `ErrorMeta` "expected error" branch unreachable for list-shaped errors. Fix: `list[model]`.

## 2. Model/API mismatches

The required-field patterns suggest the models were derived from one account's response snapshots; other account states and hardware return different shapes. Observed live (each commit message quotes the evidence):

**Null where models require a value:**
- `account.py`: `NetworkInfo.amazon_directed_id`, `PremiumDetails.interval` — null for non-Amazon-linked / non-subscribed accounts. This breaks `Account` validation, and since `Eero.network_clients` depends on `.account`, the client is effectively unusable for such accounts (`AttributeError: 'dict' object has no attribute 'networks'`).
- `networks.py`: `Networks.amazon_directed_id`, `amazon_full_name`, second `PremiumDetails.interval`, `ring_lte`, `last_reboot`; `EeroDevice.ethernet_addresses` (null on Beacons — no ethernet ports), `EeroDevice.last_reboot`, `lldpInfo` entry values.
- `thread.py`: `border_agent` absent on some networks.

**Objects where models expect strings:**
- `Device.usage` → `{down_mbps, up_mbps}` (new `DeviceUsage` model)
- `Device.ipv6_addresses` entries → `{address, scope}` (new `DeviceIPv6Address` model)
- `EeroDevice.nightlight` → `{enabled, brightness, schedule}` on Beacons (new `Nightlight` model)
- `DHCP.custom` → `{subnet_ip, subnet_mask, start_ip, end_ip}` with a custom DHCP range (new `DHCPCustomRange` model)
- `Networks.ipv6_lease` → `{prefix, subnets, name_servers}` with ISP IPv6 delegation (new `IPv6Lease` model)
- `EeroDeviceEthernetStatusItem.neighbor` → object (eero node reference) as well as string

Also: `logger.warn` → `logger.warning` (deprecated).

## Backward compatibility

Every change is a strict widening — required → optional, or a union that still accepts the previously-annotated string form (`DeviceUsage | str | None` etc.). No input that validated before is rejected now; populated Amazon-linked/subscribed account values round-trip unchanged. The only consumer-visible change is that type checkers will ask for None-checks on fields that could already be absent in practice.

## Validation

After these changes, all 17 GET resources validate cleanly into models on all 4 networks (previously: every list endpoint raised, and `account`/`networks`/`devices`/`eeros`/`thread` degraded to raw dicts on at least one network). Happy to share redacted response payloads for any of the observed shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)