### PR TITLE
Harden API response and session secret handling

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security considerations
+
+The session cookie grants the same network access as the authenticated account.
+`FileSessionStorage` stores it with owner-only permissions (`0600`) and replaces
+the file atomically when the session is refreshed. Keep the cookie outside
+source control and do not share it.
+
+Setting `DEBUGGING_PATH` writes raw API responses for troubleshooting. Those
+responses can contain account details, Wi-Fi passwords, and Thread credentials.
+The directory and response files are restricted to the current user, but they
+should still be treated as secrets and deleted when debugging is complete.

--- a/eero/client/api_client.py
+++ b/eero/client/api_client.py
@@ -44,7 +44,7 @@ class APIClient:
 
     def _parse_response(self, action, response) -> dict[str, Any]:
         data = json.loads(response.text)
-        logger.debug("Response for %s: %s", action, data)
+        logger.debug("Received response for %s", action)
         try:
             if data["meta"]["code"] not in [
                 HTTPStatus.OK,
@@ -64,7 +64,7 @@ class APIClient:
         except ClientException as e:
             raise e
         except Exception as e:
-            logger.error("KeyError - Failed to parse response: %s [%s]", data, e)
+            logger.error("Failed to parse response for %s: %s", action, e)
             try:
                 raise ClientException(
                     data.get("result", {}).get("error", {}).get("requestId"),

--- a/eero/client/routes/method_factory.py
+++ b/eero/client/routes/method_factory.py
@@ -17,10 +17,39 @@ DEBUGGING_PATH = (
     if (raw_debugging_path := os.environ.get("DEBUGGING_PATH", None))
     else None
 )
-if DEBUGGING_PATH:
-    DEBUGGING_PATH.mkdir(parents=True, exist_ok=True)
-
 logger.debug("DEBUGGING_PATH: %s", DEBUGGING_PATH)
+
+
+def _write_debug_payload(action: str, result: Any) -> None:
+    """Write an explicitly requested raw response with restricted permissions."""
+    if DEBUGGING_PATH is None:
+        return
+
+    DEBUGGING_PATH.mkdir(mode=0o700, parents=True, exist_ok=True)
+    if os.name != "nt":
+        DEBUGGING_PATH.chmod(0o700)
+    output_path = DEBUGGING_PATH / f"{action}.json"
+    file_descriptor = os.open(
+        output_path,
+        os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+        0o600,
+    )
+    with os.fdopen(file_descriptor, "w") as output_file:
+        json.dump(result, output_file, indent=2)
+    if os.name != "nt":
+        output_path.chmod(0o600)
+
+
+def _validation_error_summary(error: ValidationError) -> list[dict[str, Any]]:
+    """Return validation diagnostics without values or validator messages."""
+    return [
+        {"location": item["loc"], "type": item["type"]}
+        for item in error.errors(
+            include_url=False,
+            include_context=False,
+            include_input=False,
+        )
+    ]
 
 
 def make_method(method: str, action: str, resource: Resource, **kwargs: Any):
@@ -36,21 +65,17 @@ def make_method(method: str, action: str, resource: Resource, **kwargs: Any):
         url, model = resource
         logger.debug("%s: %s (%s)", action, url, model)
         for key, value in kwargs.items():
-            url = url.replace("<{}>".format(key), str(value))
+            url = url.replace(f"<{key}>", str(value))
 
         result = self.refreshed(lambda: self.client.request(method, url))
 
         if model is not None:
             try:
-                if DEBUGGING_PATH:
-                    (DEBUGGING_PATH / f"{action}.json").write_text(
-                        json.dumps(result, indent=2)
-                    )
+                _write_debug_payload(action, result)
 
-                logger.debug("Validating %s: %s", action, result)
+                logger.debug("Validating response for %s", action)
                 logger.debug("Model: %s", model)
                 logger.debug("Model Type: %s", type(model))
-                logger.debug("Result: %s", result)
 
                 try:
                     if isinstance(result, list):
@@ -58,21 +83,25 @@ def make_method(method: str, action: str, resource: Resource, **kwargs: Any):
                             list[type(model)]  # type: ignore
                         ).validate_python(result)
                     return model.model_validate(result)  # type: ignore
+                except ValidationError:
+                    raise
                 except Exception as e:
                     logger.error(
-                        "[%s] Failed to Marshal %s: %s",
+                        "[%s] Failed to marshal response (%s)",
                         action,
-                        e,
-                        result,
-                        exc_info=True,
+                        type(e).__name__,
                     )
-                    raise e
+                    raise
 
             except ValidationError as e:
                 if model == ErrorMeta:
-                    logger.warn(f"Not Implemented: {action} (expected error)")
+                    logger.warning("Not Implemented: %s (expected error)", action)
                     return result
-                logger.error("Failed to validate %s: %s", action, e)
+                logger.error(
+                    "Failed to validate %s: %s",
+                    action,
+                    _validation_error_summary(e),
+                )
         return result
 
     return lambda self, **caller_kwargs: func(self, **kwargs, **caller_kwargs)

--- a/eero/session/file.py
+++ b/eero/session/file.py
@@ -1,24 +1,50 @@
+import os
+import tempfile
+from pathlib import Path
+
 from .abc import SessionStorage
 
 
 class FileSessionStorage(SessionStorage):
-    def __init__(self, cookie_file):
-        from os import path
-
-        self.cookie_file = path.abspath(cookie_file)
+    def __init__(self, cookie_file: str | os.PathLike[str]) -> None:
+        self.cookie_file = os.path.abspath(cookie_file)
+        self._cookie_path = Path(self.cookie_file)
+        self.__cookie: str | None
 
         try:
-            with open(self.cookie_file, "r") as f:
-                self.__cookie = f.read()
-        except IOError:
+            self.__cookie = self._cookie_path.read_text()
+            if os.name != "nt":
+                self._cookie_path.chmod(0o600)
+        except OSError:
             self.__cookie = None
 
     @property
-    def cookie(self):
+    def cookie(self) -> str | None:
         return self.__cookie
 
     @cookie.setter
-    def cookie(self, cookie):
-        self.__cookie = cookie
-        with open(self.cookie_file, "w+") as f:
-            f.write(self.__cookie)
+    def cookie(self, cookie: str) -> None:
+        file_descriptor, temporary_path = tempfile.mkstemp(
+            dir=self._cookie_path.parent,
+            prefix=f".{self._cookie_path.name}.",
+            text=True,
+        )
+        try:
+            if os.name != "nt":
+                os.fchmod(file_descriptor, 0o600)
+            with os.fdopen(file_descriptor, "w") as cookie_file:
+                cookie_file.write(cookie)
+            os.replace(temporary_path, self._cookie_path)
+            if os.name != "nt":
+                self._cookie_path.chmod(0o600)
+            self.__cookie = cookie
+        except OSError:
+            try:
+                os.close(file_descriptor)
+            except OSError:
+                pass
+            try:
+                os.unlink(temporary_path)
+            except FileNotFoundError:
+                pass
+            raise

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,151 @@
+import json
+import logging
+import os
+from pathlib import Path
+from stat import S_IMODE
+from types import SimpleNamespace
+
+import pytest
+from pydantic import BaseModel, field_validator
+
+from eero.client.api_client import APIClient
+from eero.client.routes import method_factory
+from eero.client.routes.routes import Resource
+from eero.exceptions import ClientException
+from eero.session import FileSessionStorage
+
+SECRET = "sensitive-marker-that-must-not-be-logged"
+
+
+class ExpectedResponse(BaseModel):
+    required_field: str
+
+
+class RejectedResponse(BaseModel):
+    password: str
+
+    @field_validator("password")
+    @classmethod
+    def reject_password(cls, value: str) -> str:
+        raise ValueError(f"rejected sensitive value: {value}")
+
+
+class FakeAPI:
+    def __init__(self, result):
+        self.client = SimpleNamespace(request=lambda method, url: result)
+
+    @staticmethod
+    def refreshed(func):
+        return func()
+
+
+def test_validation_failure_does_not_log_response_payload(caplog) -> None:
+    caplog.set_level(logging.DEBUG, logger="eero")
+    response = {"password": SECRET}
+
+    result = method_factory.make_method(
+        "get",
+        "network",
+        Resource("network", ExpectedResponse),
+    )(FakeAPI(response))
+
+    assert result == response
+    assert SECRET not in caplog.text
+
+
+def test_validator_message_does_not_log_sensitive_value(caplog) -> None:
+    caplog.set_level(logging.DEBUG, logger="eero")
+    response = {"password": SECRET}
+
+    result = method_factory.make_method(
+        "get",
+        "network",
+        Resource("network", RejectedResponse),
+    )(FakeAPI(response))
+
+    assert result == response
+    assert SECRET not in caplog.text
+
+
+def test_api_client_does_not_log_success_payload(caplog) -> None:
+    caplog.set_level(logging.DEBUG, logger="eero")
+    response = SimpleNamespace(
+        text=json.dumps({"meta": {"code": 200}, "data": {"password": SECRET}})
+    )
+
+    result = APIClient()._parse_response("network", response)
+
+    assert result == {"password": SECRET}
+    assert SECRET not in caplog.text
+
+
+def test_api_client_does_not_log_malformed_payload(caplog) -> None:
+    caplog.set_level(logging.DEBUG, logger="eero")
+    response = SimpleNamespace(text=json.dumps({"password": SECRET}))
+
+    with pytest.raises(ClientException):
+        APIClient()._parse_response("network", response)
+
+    assert SECRET not in caplog.text
+
+
+def test_debug_payload_has_owner_only_permissions(tmp_path: Path, monkeypatch) -> None:
+    debug_path = tmp_path / "debug"
+    monkeypatch.setattr(method_factory, "DEBUGGING_PATH", debug_path)
+
+    method_factory._write_debug_payload("network", {"password": SECRET})
+
+    output_path = debug_path / "network.json"
+    assert json.loads(output_path.read_text()) == {"password": SECRET}
+    if os.name != "nt":
+        assert S_IMODE(debug_path.stat().st_mode) == 0o700
+        assert S_IMODE(output_path.stat().st_mode) == 0o600
+
+
+def test_file_session_storage_writes_cookie_atomically_with_owner_only_permissions(
+    tmp_path: Path,
+) -> None:
+    cookie_path = tmp_path / "session.cookie"
+    storage = FileSessionStorage(cookie_path)
+
+    storage.cookie = SECRET
+
+    assert isinstance(storage.cookie_file, str)
+    assert cookie_path.read_text() == SECRET
+    assert not list(tmp_path.glob(".session.cookie.*"))
+    if os.name != "nt":
+        assert S_IMODE(cookie_path.stat().st_mode) == 0o600
+
+
+def test_file_session_storage_restricts_existing_cookie_permissions(
+    tmp_path: Path,
+) -> None:
+    cookie_path = tmp_path / "session.cookie"
+    cookie_path.write_text(SECRET)
+    cookie_path.chmod(0o644)
+
+    storage = FileSessionStorage(cookie_path)
+
+    assert storage.cookie == SECRET
+    if os.name != "nt":
+        assert S_IMODE(cookie_path.stat().st_mode) == 0o600
+
+
+def test_file_session_storage_preserves_cookie_when_atomic_replace_fails(
+    tmp_path: Path, monkeypatch
+) -> None:
+    cookie_path = tmp_path / "session.cookie"
+    cookie_path.write_text("existing-cookie")
+    storage = FileSessionStorage(cookie_path)
+
+    def fail_replace(source, destination):
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="simulated replace failure"):
+        storage.cookie = SECRET
+
+    assert storage.cookie == "existing-cookie"
+    assert cookie_path.read_text() == "existing-cookie"
+    assert not list(tmp_path.glob(".session.cookie.*"))


### PR DESCRIPTION
## What changed

- stop logging raw API response payloads during normal debug, parse-error, and model-validation paths
- reduce Pydantic validation diagnostics to field locations and error types, excluding input values and custom validator messages
- restrict explicitly requested `DEBUGGING_PATH` directories to `0700` and response files to `0600` on POSIX
- persist `FileSessionStorage` cookies through owner-only atomic replacement while preserving the existing public `cookie_file` string attribute
- preserve the prior in-memory and on-disk cookie if atomic replacement fails
- document the sensitivity of session cookies and raw debug responses
- add regression tests for payload redaction, custom-validator redaction, file permissions, atomic writes, and failure cleanup

## Why

While reproducing the non-Amazon account validation failure addressed by #8, a model-validation error logged the complete account response. Other Eero endpoints can contain Wi-Fi passwords and Thread credentials, so logging the response or Pydantic input values can disclose secrets even when the caller did not enable raw response dumps.

This PR is intentionally independent of #8: it does not change endpoint models or response-validation behavior.

## Impact

Normal logs retain the endpoint/action, exception class, and validation field/type information without response values. Users who explicitly opt into `DEBUGGING_PATH` still receive raw troubleshooting payloads, now with restrictive local permissions and clearer security documentation.

## Validation

- `ruff check eero/client/routes/method_factory.py eero/session/file.py tests/test_security.py`
- `mypy .`
- `pytest` — 9 passed
- `uv build`
- `git diff --check`

No real account or network payloads are included in the tests or commit.
